### PR TITLE
Errs when invacuating a node

### DIFF
--- a/elkvacuate.rb
+++ b/elkvacuate.rb
@@ -158,20 +158,6 @@ def invacuate_node(invacuating_node)
             puts "Waiting 10 seconds before continuing..."
             sleep 10
         end
-        begin
-            if not include_list.include?("#{invacuating_node}")
-                puts "Adding node to include list..."
-                include_list = add_node_to_list(include_list, invacuating_node)
-                settings_json = JSON.generate({ 'index' => { 'routing' => { 'allocation' => { 'include' => { '_host' => "#{include_list}" } } } } })
-                response = @http.put("/#{index}/_settings", settings_json)
-                puts "#{response.body} (#{response.code} #{response.message})"
-                sleep 10
-            end
-        rescue Exception => e
-            puts "Error setting new include list for index #{index}: #{e}"
-            puts "Waiting 10 seconds before continuing..."
-            sleep 10
-        end
     end
 end
 


### PR DESCRIPTION
So we have this situation where our cluster is configured in AWS and all nodes are included in our shard allocation. If I execute an invacuation of data the script basically adds the host to the include list and removes it from the exclude host causing that all of our shards are going to only one node.

I guess the right behavior would be just to remove the node from the exclude list instead of also adding it to the include list.
